### PR TITLE
Adding conda-forge as channel to build and deploy the documentation

### DIFF
--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -1,4 +1,5 @@
 channels:
+- conda-forge
 - defaults
 dependencies:
 - python

--- a/devtools/requirements.yaml
+++ b/devtools/requirements.yaml
@@ -23,8 +23,8 @@ test: # inherits production
 
 docs: # inherits production
   channels:
-    - *production_channels
     - conda-forge
+    - *production_channels
   dependencies:
     - *production_dependencies
     - jupyterlab


### PR DESCRIPTION
Fixing the previous PR to work with the documentation conda env.